### PR TITLE
bug: 상속 구조를 제거(extends ResponseEntityExceptionHandler 삭제)(#10)

### DIFF
--- a/src/main/java/demago/gamjappang/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/demago/gamjappang/global/error/handler/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+public class GlobalExceptionHandler {
 
     @ExceptionHandler(GamjaException.class)
     public ResponseEntity<ErrorResponse> handleGamjaException(GamjaException e, HttpServletRequest request) {


### PR DESCRIPTION
## Summary
- GlobalExceptionHandler가 ResponseEntityExceptionHandler를 상속하면서, 일부 예외를 @ExceptionHandler로 중복 처리하던 구조를 정리했습니다.
- 예외 처리 흐름을 단일화하여 요청 누락/검증 실패 등에서 응답 포맷이 상황에 따라 달라지거나 핸들러가 의도와 다르게 선택되는 문제를 해소했습니다.

## Related Issue
- Related: #10 

## Root Cause
- GlobalExceptionHandler extends ResponseEntityExceptionHandler 구조로 인해 Spring MVC 기본 처리 루트와 커스텀 @ExceptionHandler가 동일/유사 예외를 각각 처리할 수 있는 상태였습니다.
- 그 결과 MissingServletRequestParameterException 등 일부 예외에서 어떤 핸들러가 호출되는지 일관되지 않아 표준 에러 응답 포맷이 깨지거나 예외 처리 경로가 혼선되는 문제가 발생했습니다.

## Fix Description
- GlobalExceptionHandler에서 extends ResponseEntityExceptionHandler 제거
- 예외 응답을 프로젝트 표준 포맷으로 통일하도록 @ExceptionHandler 기반으로 처리 경로 정리
- 중복/유사 예외 처리 로직 제거 및 에러코드 매핑/메시지 일관성 유지

## Testing
- No response

## Risk & Impact
- Risk level: Low

## Checklist
- No response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 글로벌 예외 처리기의 구조를 개선했습니다. 예외 처리 로직 및 기능에는 변화가 없으며, 예외 처리 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->