### PR TITLE
Refactor: discord web hock 리펙토링(#23)

### DIFF
--- a/src/main/java/demago/gamjappang/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/demago/gamjappang/global/error/handler/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package demago.gamjappang.global.error.handler;
 import demago.gamjappang.global.error.ErrorResponse;
 import demago.gamjappang.global.error.GlobalErrorCode;
 import demago.gamjappang.global.error.exception.GamjaException;
+import demago.gamjappang.global.feignclient.webhook.SendService;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -22,12 +24,21 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final SendService sendService;
 
     @ExceptionHandler(GamjaException.class)
     public ResponseEntity<ErrorResponse> handleGamjaException(GamjaException e, HttpServletRequest request) {
         var ec = e.getErrorCode();
         String message = e.getMessage() != null ? e.getMessage() : ec.getMessage();
+
+        try {
+            sendService.sendDiscordAlert(e, request.getMethod(), request.getRequestURI());
+        } catch (Exception ex) {
+            log.warn("Discord 알림 전송 실패", ex);
+        }
 
         return ResponseEntity
                 .status(ec.getStatus())
@@ -78,6 +89,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleUnexpected(Exception e, HttpServletRequest request) {
         // 서버 로그에만 스택 트레이스 남기고, 응답은 안전하게
         log.error("Unexpected exception: {} {}", request.getMethod(), request.getRequestURI(), e);
+        sendService.sendDiscordAlert(e, request.getMethod(), request.getRequestURI());
 
         return ResponseEntity
                 .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getStatus())

--- a/src/main/java/demago/gamjappang/global/feignclient/webhook/DiscordWebhookRequest.java
+++ b/src/main/java/demago/gamjappang/global/feignclient/webhook/DiscordWebhookRequest.java
@@ -1,4 +1,8 @@
 package demago.gamjappang.global.feignclient.webhook;
 
-public record DiscordWebhookRequest(String content) {
+import demago.gamjappang.global.feignclient.webhook.dto.Embed;
+
+import java.util.List;
+
+public record DiscordWebhookRequest(String content, List<Embed> embeds) {
 }

--- a/src/main/java/demago/gamjappang/global/feignclient/webhook/SendService.java
+++ b/src/main/java/demago/gamjappang/global/feignclient/webhook/SendService.java
@@ -1,9 +1,16 @@
 package demago.gamjappang.global.feignclient.webhook;
 
+import demago.gamjappang.global.feignclient.webhook.dto.Embed;
+import demago.gamjappang.global.feignclient.webhook.dto.Field;
+import demago.gamjappang.global.feignclient.webhook.dto.Footer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -12,33 +19,39 @@ public class SendService {
 
     private final DiscordWebhookClient discordWebhookClient;
 
-    @Async("discordAsyncExecutor") // 비동기처리
+    @Async("discordAsyncExecutor")
     public void sendDiscordAlert(Exception e, String method, String uri) {
         try {
-            String message = buildMessage(e, method, uri);
-            discordWebhookClient.send(
-                    new DiscordWebhookRequest(message)
-            );
+            DiscordWebhookRequest request = buildMessage(e, method, uri);
+            discordWebhookClient.send(request);
         } catch (Exception ex) {
             log.error("Failed to send discord webhook", ex);
         }
     }
 
-    public String buildMessage(Exception e, String method, String uri) {
-        String errorMessage = """
-            ## Internal Server Error
-            - Method: `%s`
-            - URI: `%s`
-            - %s: %s
-            """.formatted(method, uri, e.getClass().getSimpleName(),
-                e.getMessage() != null ? e.getMessage() : "(no message)");
+    public DiscordWebhookRequest buildMessage(Exception e, String method, String uri) {
+        String timestamp = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
 
+        String exceptionName = e.getClass().getSimpleName();
+        String exceptionMessage = e.getMessage() != null ? e.getMessage() : "(no message)";
 
-        // 2000자 이상이면 자름
-        if (errorMessage.length() > 2000) {
-            return errorMessage.substring(0, 1990) + "\n... (중략)";
+        if (exceptionMessage.length() > 1000) {
+            exceptionMessage = exceptionMessage.substring(0, 990) + "\n... (중략)";
         }
 
-        return errorMessage;
+        Embed embed = new Embed(
+                "🚨 Internal Server Error",
+                15158332,
+                List.of(
+                        new Field("Method", "`" + method + "`", true),
+                        new Field("URI", "`" + uri + "`", true),
+                        new Field("Exception", "`" + exceptionName + "`", false),
+                        new Field("Message", "```text\n" + exceptionMessage + "\n```", false)
+                ),
+                new Footer(timestamp)
+        );
+
+        return new DiscordWebhookRequest(null, List.of(embed));
     }
 }

--- a/src/main/java/demago/gamjappang/global/feignclient/webhook/dto/Embed.java
+++ b/src/main/java/demago/gamjappang/global/feignclient/webhook/dto/Embed.java
@@ -1,0 +1,11 @@
+package demago.gamjappang.global.feignclient.webhook.dto;
+
+import java.util.List;
+
+public record Embed(
+        String title,
+        Integer color,
+        List<Field> fields,
+        Footer footer
+) {
+}

--- a/src/main/java/demago/gamjappang/global/feignclient/webhook/dto/Field.java
+++ b/src/main/java/demago/gamjappang/global/feignclient/webhook/dto/Field.java
@@ -1,0 +1,8 @@
+package demago.gamjappang.global.feignclient.webhook.dto;
+
+public record Field(
+        String name,
+        String value,
+        boolean inline
+) {
+}

--- a/src/main/java/demago/gamjappang/global/feignclient/webhook/dto/Footer.java
+++ b/src/main/java/demago/gamjappang/global/feignclient/webhook/dto/Footer.java
@@ -1,0 +1,6 @@
+package demago.gamjappang.global.feignclient.webhook.dto;
+
+public record Footer(
+        String text
+) {
+}

--- a/src/test/java/demago/gamjappang/global/feignclient/webhook/SendServiceTest.java
+++ b/src/test/java/demago/gamjappang/global/feignclient/webhook/SendServiceTest.java
@@ -1,18 +1,23 @@
 package demago.gamjappang.global.feignclient.webhook;
 
+import demago.gamjappang.global.feignclient.webhook.dto.Embed;
+import demago.gamjappang.global.feignclient.webhook.dto.Field;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class SendServiceTest {
 
     @Autowired
@@ -22,76 +27,80 @@ class SendServiceTest {
     private DiscordWebhookClient discordWebhookClient;
 
     @Test
-    void sendDiscordAlert_Success() throws InterruptedException {
-        // When
-        sendService.sendDiscordAlert(new Exception(), "GET", "/test");
+    void sendDiscordAlert_success() throws InterruptedException {
+        sendService.sendDiscordAlert(new Exception("테스트 예외"), "GET", "/test");
 
-        // 비동기 실행 대기
         Thread.sleep(500);
 
-        // Then: 가짜 클라이언트의 send 메소드가 호출되었는지 검증
         verify(discordWebhookClient).send(any(DiscordWebhookRequest.class));
     }
 
     @Test
     void buildMessage() {
-        Exception e = new RuntimeException("이것은 테스트 에러 메시지입니다. ".repeat(100)); // 아주 긴 에러
+        Exception e = new RuntimeException("이것은 테스트 에러 메시지입니다. ".repeat(100));
 
-        // MockRequest 생성 (실제 서블릿 객체 대신 가짜 객체 사용)
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setMethod("POST");
-        request.setRequestURI("/api/test");
+        DiscordWebhookRequest request = sendService.buildMessage(e, "POST", "/api/test");
 
-        // When
-        String message = sendService.buildMessage(e, request.getMethod(), request.getRequestURI());
+        assertThat(request).isNotNull();
+        assertThat(request.embeds()).hasSize(1);
 
-        // Then
-        assertThat(message).contains("Internal Server Error");
-        assertThat(message).contains("POST");
-        assertThat(message.length()).isLessThanOrEqualTo(2000); // 2000자 이하인지 확인
-        if (message.length() >= 2000) {
-            assertThat(message).endsWith("... (중략)"); // 잘렸을 때 점 세 개로 끝나는지
-        }
+        Embed embed = request.embeds().get(0);
+        assertThat(embed.title()).contains("Internal Server Error");
+        assertThat(embed.fields()).isNotNull();
+
+        List<Field> fields = embed.fields();
+
+        assertThat(fields).extracting(Field::name)
+                .contains("Method", "URI", "Exception", "Message");
+
+        assertThat(fields).extracting(Field::value)
+                .anyMatch(value -> value.contains("POST"))
+                .anyMatch(value -> value.contains("/api/test"));
     }
 
     @Test
     void buildMessage_shouldTruncate_whenExceedsLimit() {
-        // Given: 2000자가 훨씬 넘는 아주 긴 에러 메시지 준비
         String longErrorMessage = "A".repeat(3000);
         Exception e = new RuntimeException(longErrorMessage);
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setMethod("POST");
-        request.setRequestURI("/api/test-limit");
 
-        // When: 메시지 생성
-        String result = sendService.buildMessage(e, request.getMethod(), request.getRequestURI());
+        DiscordWebhookRequest request = sendService.buildMessage(e, "POST", "/api/test-limit");
 
-        // Then: 검증
-        assertThat(result.length()).isLessThanOrEqualTo(2000);
-        assertThat(result).endsWith("... (중략)");
-        assertThat(result).contains("POST");
-        assertThat(result).contains("/api/test-limit");
+        assertThat(request).isNotNull();
+        assertThat(request.embeds()).hasSize(1);
 
-        System.out.println("최종 메시지 길이: " + result.length());
+        Embed embed = request.embeds().get(0);
+        List<Field> fields = embed.fields();
+
+        Field messageField = fields.stream()
+                .filter(field -> field.name().equals("Message"))
+                .findFirst()
+                .orElseThrow();
+
+        Field methodField = fields.stream()
+                .filter(field -> field.name().equals("Method"))
+                .findFirst()
+                .orElseThrow();
+
+        Field uriField = fields.stream()
+                .filter(field -> field.name().equals("URI"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(methodField.value()).contains("POST");
+        assertThat(uriField.value()).contains("/api/test-limit");
+        assertThat(messageField.value()).contains("... (중략)");
 
         assertDoesNotThrow(() -> {
-            sendService.sendDiscordAlert(e, request.getMethod(), request.getRequestURI());
+            sendService.sendDiscordAlert(e, "POST", "/api/test-limit");
         });
     }
 
     @Test
     void asyncTest() {
-        // Given
         Exception e = new RuntimeException("비동기 테스트 에러");
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setMethod("GET");
-        request.setRequestURI("/api/async-test");
 
-        // When
-        sendService.sendDiscordAlert(e, request.getMethod(), request.getRequestURI());
+        sendService.sendDiscordAlert(e, "GET", "/api/async-test");
 
-        // Then
-        // 최대 2000ms(2초) 동안 비동기 호출이 일어나는지 기다리며 검증합니다.
         verify(discordWebhookClient, timeout(2000)).send(any(DiscordWebhookRequest.class));
     }
 }


### PR DESCRIPTION
## Summary

* Discord Webhook 메시지의 body를 DTO로 변경하고, GlobalExceptionHandler에서 예외 발생 시 메시지 전송 로직을 추가했습니다.

## Related Issue

* Resolved #23

## Root Cause

* 기존에는 GlobalExceptionHandler에서 예외 발생 시 Discord Webhook으로 에러 메시지를 전송해야 했지만, 관련 로직이 없어 메시지 전송이 불가능했습니다.
* 메시지와 body가 하드코딩되어 있어 유지보수가 어려웠습니다.

## Fix Description

* 예외 발생 시 Discord Webhook URL에 연결된 Discord 앱으로 로그 메시지를 전송하도록 구현했습니다.
* 예외 메시지 구조를 DTO로 변경하여 유지보수성을 높였습니다.

## Testing

* 예외가 발생하는 상황을 만들어 GlobalExceptionHandler가 정상적으로 동작하는지 확인했습니다.
* 예외 발생 시 Discord 채널로 로그 메시지가 정상 전송되는 것을 확인했습니다.
* DTO 변경 이후에도 기존 메시지 형식이 의도한 구조로 잘 전달되는지 확인했습니다.

## Risk & Impact

* 예외 발생 시 외부 Webhook 호출이 추가되므로, Discord Webhook 서버 상태에 따라 전송 실패 가능성이 있습니다.
* 다만, Webhook 전송 실패가 기존 예외 처리 흐름 자체에 치명적인 영향을 주지 않도록 관리가 필요합니다.
* 운영 중 예외 로그를 빠르게 확인할 수 있어 장애 대응 속도 향상이 기대됩니다.

## Checklist

* [x] 예외 발생 시 Discord 메시지 전송 로직을 추가했습니다.
* [x] 메시지 body를 DTO로 리팩터링했습니다.
* [x] 관련 동작을 직접 테스트했습니다.
* [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 애플리케이션 에러 발생 시 Discord를 통한 알림 기능 개선
  * 알림 메시지가 구조화된 형식으로 제공되어 더욱 읽기 쉬워짐
  * 알림에 타임스탬프, 요청 메서드, URI, 예외명, 예외 메시지 등 상세 정보 포함

* **Tests**
  * Discord 알림 기능 관련 테스트 코드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->